### PR TITLE
added the parameter entity class, because delete qeury doesnt work wi…

### DIFF
--- a/src/AbstractEntityService.php
+++ b/src/AbstractEntityService.php
@@ -227,20 +227,18 @@ abstract class AbstractEntityService extends AbstractListenerAggregate implement
     /**
      * Deletes all objects matching the criteria from the repository
      *
-     * @param object $entityClass the class of the entity on which to run the delete query
      * @param Criteria $criteria The criteria values to match on.
      * @return mixed
      * @throws \Zend\EventManager\Exception\InvalidArgumentException
      * @throws \PolderKnowledge\EntityService\Exception\RuntimeException
      */
-    public function deleteBy($entityClass, Criteria $criteria)
+    public function deleteBy(Criteria $criteria)
     {
         if (!$this->isRepositoryDeletable()) {
             throw $this->createNotDeletableException();
         }
 
         return $this->trigger(__FUNCTION__, [
-            'entityClass' => $entityClass,
             'criteria' => $criteria,
         ]);
     }

--- a/src/AbstractEntityService.php
+++ b/src/AbstractEntityService.php
@@ -227,18 +227,20 @@ abstract class AbstractEntityService extends AbstractListenerAggregate implement
     /**
      * Deletes all objects matching the criteria from the repository
      *
-     * @param array|Criteria $criteria The criteria values to match on.
+     * @param object $entityClass the class of the entity on which to run the delete query
+     * @param Criteria $criteria The criteria values to match on.
      * @return mixed
      * @throws \Zend\EventManager\Exception\InvalidArgumentException
      * @throws \PolderKnowledge\EntityService\Exception\RuntimeException
      */
-    public function deleteBy($criteria)
+    public function deleteBy($entityClass, Criteria $criteria)
     {
         if (!$this->isRepositoryDeletable()) {
             throw $this->createNotDeletableException();
         }
 
         return $this->trigger(__FUNCTION__, [
+            'entityClass' => $entityClass,
             'criteria' => $criteria,
         ]);
     }

--- a/src/EntityServiceInterface.php
+++ b/src/EntityServiceInterface.php
@@ -38,9 +38,10 @@ interface EntityServiceInterface extends EventManagerAwareInterface
     /**
      * Deletes all objects matching the criteria from the repository
      *
-     * @param array|Criteria $criteria The criteria values to match on.
+     * @param object $entityClass the class of the entity on which to run the delete query
+     * @param Criteria $criteria The criteria values to match on.
      */
-    public function deleteBy($criteria);
+    public function deleteBy($entityClass, Criteria $criteria);
 
     /**
      * Find one object in the repository matching the $id

--- a/src/EntityServiceInterface.php
+++ b/src/EntityServiceInterface.php
@@ -38,10 +38,9 @@ interface EntityServiceInterface extends EventManagerAwareInterface
     /**
      * Deletes all objects matching the criteria from the repository
      *
-     * @param object $entityClass the class of the entity on which to run the delete query
      * @param Criteria $criteria The criteria values to match on.
      */
-    public function deleteBy($entityClass, Criteria $criteria);
+    public function deleteBy(Criteria $criteria);
 
     /**
      * Find one object in the repository matching the $id

--- a/src/Repository/Doctrine/CollectionRepository.php
+++ b/src/Repository/Doctrine/CollectionRepository.php
@@ -35,7 +35,7 @@ class CollectionRepository implements
         $this->persisted->removeElement($entity);
     }
 
-    public function deleteBy($criteria)
+    public function deleteBy(Criteria $criteria)
     {
         $criteria = Util::normalizeCriteria($criteria);
 

--- a/src/Repository/Doctrine/ORMRepository.php
+++ b/src/Repository/Doctrine/ORMRepository.php
@@ -114,16 +114,17 @@ class ORMRepository implements
     /**
      * Removes objects by a set of criteria.
      *
-     * @param array|Criteria $criteria
+     * @param object $entityClass the class of the entity on which to run the delete query
+     * @param Criteria $criteria
      * @return void
      * @throws \Doctrine\ORM\Query\QueryException
      */
-    public function deleteBy($criteria)
+    public function deleteBy($entityClass, Criteria $criteria)
     {
         $criteria = Util::normalizeCriteria($criteria);
 
         $queryBuilder = $this->getQueryBuilder($criteria);
-        $queryBuilder->delete('e');
+        $queryBuilder->delete($entityClass, 'e');
         $queryBuilder->getQuery()->execute();
     }
 

--- a/src/Repository/Doctrine/ORMRepository.php
+++ b/src/Repository/Doctrine/ORMRepository.php
@@ -114,17 +114,16 @@ class ORMRepository implements
     /**
      * Removes objects by a set of criteria.
      *
-     * @param object $entityClass the class of the entity on which to run the delete query
      * @param Criteria $criteria
      * @return void
      * @throws \Doctrine\ORM\Query\QueryException
      */
-    public function deleteBy($entityClass, Criteria $criteria)
+    public function deleteBy(Criteria $criteria)
     {
         $criteria = Util::normalizeCriteria($criteria);
 
         $queryBuilder = $this->getQueryBuilder($criteria);
-        $queryBuilder->delete($entityClass, 'e');
+        $queryBuilder->delete($this->entityName, 'e');
         $queryBuilder->getQuery()->execute();
     }
 

--- a/src/Repository/Feature/DeletableInterface.php
+++ b/src/Repository/Feature/DeletableInterface.php
@@ -26,9 +26,8 @@ interface DeletableInterface
     /**
      * Removes objects by a set of criteria.
      *
-     * @param object $entityClass the class of the entity on which to run the delete query
      * @param Criteria $criteria
      * @return int Returns the number of records that are deleted.
      */
-    public function deleteBy($entityClass, Criteria $criteria);
+    public function deleteBy(Criteria $criteria);
 }

--- a/src/Repository/Feature/DeletableInterface.php
+++ b/src/Repository/Feature/DeletableInterface.php
@@ -26,8 +26,9 @@ interface DeletableInterface
     /**
      * Removes objects by a set of criteria.
      *
-     * @param array|Criteria $criteria
+     * @param object $entityClass the class of the entity on which to run the delete query
+     * @param Criteria $criteria
      * @return int Returns the number of records that are deleted.
      */
-    public function deleteBy($criteria);
+    public function deleteBy($entityClass, Criteria $criteria);
 }

--- a/tests/EntityServiceTest/AbstractEntityServiceTest.php
+++ b/tests/EntityServiceTest/AbstractEntityServiceTest.php
@@ -9,6 +9,7 @@
 
 namespace PolderKnowledge\EntityServiceTest;
 
+use Doctrine\Common\Collections\Criteria;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
 use PolderKnowledge\EntityService\AbstractEntityService;
@@ -185,9 +186,10 @@ class AbstractEntityServiceTest extends PHPUnit_Framework_TestCase
     {
         // Arrange
         $this->repository->expects($this->exactly(1))->method('deleteBy');
+        $criteria = new Criteria();
 
         // Act
-        $this->service->deleteBy([]);
+        $this->service->deleteBy($criteria);
 
         // Assert
         // ...
@@ -205,9 +207,10 @@ class AbstractEntityServiceTest extends PHPUnit_Framework_TestCase
             $repository,
             MyEntity::class,
         ]);
+        $criteria = new Criteria();
 
         // Act
-        $service->deleteBy([]);
+        $service->deleteBy($criteria);
 
         // Assert
         // ...

--- a/tests/EntityServiceTestAsset/MyRepository.php
+++ b/tests/EntityServiceTestAsset/MyRepository.php
@@ -9,6 +9,7 @@
 
 namespace PolderKnowledge\EntityServiceTestAsset;
 
+use Doctrine\Common\Collections\Criteria;
 use PolderKnowledge\EntityService\Repository\EntityRepositoryInterface;
 use PolderKnowledge\EntityService\Repository\Feature\DeletableInterface;
 use PolderKnowledge\EntityService\Repository\Feature\FlushableInterface;
@@ -28,7 +29,7 @@ class MyRepository implements
     {
     }
 
-    public function deleteBy($criteria)
+    public function deleteBy(Criteria $criteria)
     {
     }
 

--- a/tests/EntityServiceTestAsset/MyRepositoryNonTransaction.php
+++ b/tests/EntityServiceTestAsset/MyRepositoryNonTransaction.php
@@ -9,6 +9,7 @@
 
 namespace PolderKnowledge\EntityServiceTestAsset;
 
+use Doctrine\Common\Collections\Criteria;
 use PolderKnowledge\EntityService\Repository\EntityRepositoryInterface;
 use PolderKnowledge\EntityService\Repository\Feature\DeletableInterface;
 use PolderKnowledge\EntityService\Repository\Feature\FlushableInterface;
@@ -26,7 +27,7 @@ class MyRepositoryNonTransaction implements
     {
     }
 
-    public function deleteBy($criteria)
+    public function deleteBy(Criteria $criteria)
     {
     }
 


### PR DESCRIPTION
…thout knowing the entity to preform delete on

<!--- Provide a general summary of your changes in the Title above -->

## Description

The deleteBy function doesnt work with an array and doesn't work without knowing the entity on which to do the delete. Changed to needing criterea and added the paramter entityClass.

## Motivation and context

Other libraries gave a fatal error when deleteBy was used.


